### PR TITLE
Add docker support

### DIFF
--- a/build-docker
+++ b/build-docker
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+IMAGE=ebook-template
+VERSION=1.0
+
+if ! [ -z "$http_proxy" ]; then
+        BUILD_ARG_HTTP="--build-arg http_proxy=$http_proxy"
+fi
+
+if ! [ -z "$https_proxy" ]; then
+        BUILD_ARG_HTTPS="--build-arg https_proxy=$https_proxy"
+fi
+
+if [ $(docker images -q "${IMAGE}:${VERSION}" | wc -l) -eq 0 ]; then
+  echo "Building docker image, please wait"
+  docker build \
+    ${BUILD_ARG_HTTP} \
+    ${BUILD_ARG_HTTPS} \
+    -t ${IMAGE}:${VERSION} docker
+fi
+
+docker run -it --rm --name ebook \
+  -v $(pwd):/home/user/book \
+  ${IMAGE}:${VERSION} ./build $@

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,58 @@
+FROM ubuntu:17.10
+
+ENV USERNAME              user
+ENV UID                   1000
+ENV GID                   1000
+
+RUN \
+  sed -i \
+    s/archive\.ubuntu\.com/la-mirrors.evowise.com/g /etc/apt/sources.list && \
+  apt-get update && \
+  apt-get install --no-install-recommends -y \
+    texlive \
+    texlive-latex-recommended \
+    texlive-latex-extra \
+    texlive-lang-spanish \
+    texlive-xetex \
+    lmodern \
+    ttf-ubuntu-font-family \
+    openjdk-8-jre \
+    virtualenv python-virtualenv \
+    locales \
+    curl && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN locale-gen es_AR.UTF-8 && update-locale
+ENV LC_ALL es_AR.UTF-8
+
+RUN curl -LO \
+  https://github.com/jgm/pandoc/releases/download/2.0.6/pandoc-2.0.6-1-amd64.deb && \
+  dpkg -i pandoc-2.0.6-1-amd64.deb && \
+  rm pandoc-2.0.6-1-amd64.deb
+
+RUN curl -L -o /usr/local/bin/plantuml.jar \
+  http://sourceforge.net/projects/plantuml/files/plantuml.jar/download
+ADD plantuml /usr/local/bin/
+
+RUN \
+  groupadd --gid ${GID} ${USERNAME} && \
+  useradd --uid ${UID} --gid ${GID} --create-home ${USERNAME}
+
+ADD entrypoint.sh /
+RUN sed -i s/USERNAME/${USERNAME}/g /entrypoint.sh
+
+USER      ${USERNAME}
+
+RUN virtualenv -p python3 /home/${USERNAME}/env
+
+RUN \
+  . /home/${USERNAME}/env/bin/activate && \
+  curl -L -o /tmp/requirements.txt \
+     https://raw.githubusercontent.com/bmc/ebook-template/master/requirements.txt && \
+  pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt && \
+  pip install WeasyPrint
+
+WORKDIR   /home/${USERNAME}/book
+VOLUME    /home/${USERNAME}/book
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source /home/USERNAME/env/bin/activate
+
+exec "$@"

--- a/docker/plantuml
+++ b/docker/plantuml
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+java -jar /usr/local/bin/plantuml.jar $@


### PR DESCRIPTION
I've added support to build the ebook inside a Docker container.  This solution avoids installing all dependencies in the host computer.  You only have to install [docker](https://docs.docker.com/engine/installation/).

Use it just running the wrapper script `build-docker`:

```sh
$ ./build-docker 
```
The first time it will build a Docker image with all the dependencies (can take some minutes).