### PR TITLE
Fixed pandoc version checking.

### DIFF
--- a/build
+++ b/build
@@ -511,7 +511,7 @@ def _check_pandoc():
         raise Exception('Unable to determine pandoc version.')
 
     version = [int(v) for v in version]
-    if (version[0] < 2) or (version[2] < 4):
+    if (version[0] < 2) or (version[1] == 0 and version[2] < 4):
         raise Exception(
             'Pandoc version is {0}. Version 2.0.4 or newer is required.'.format(
                 '.'.join([str(i) for i in version])


### PR DESCRIPTION
Pandoc version checking fails for version 2.2.1 although it's greater than 2.0.4. The patch version is less than 4, but we're ignoring the minor version (i.e. 2 > 0).

Thank you for putting together this repository, it's really useful!